### PR TITLE
Prepare hotfix v0.2.1

### DIFF
--- a/pydid/doc/builder.py
+++ b/pydid/doc/builder.py
@@ -222,7 +222,7 @@ class DIDDocumentBuilder:
     @validate_init(id_=Switch(All(str, Coerce(DID)), DID))
     def __init__(
         self,
-        id_: Union[str, DID],
+        id_: DID,
         context: List[str] = None,
         *,
         also_known_as: List[str] = None,
@@ -250,36 +250,36 @@ class DIDDocumentBuilder:
     def from_doc(cls, doc: DIDDocument) -> "DIDDocumentBuilder":
         """Create a Builder from an existing DIDDocument."""
         builder = cls(
-            id_=doc.id,
+            id_=doc.did,
             context=doc.context,
             also_known_as=doc.also_known_as,
             controller=doc.controller,
         )
         builder.verification_methods = VerificationMethodBuilder(
-            doc.id, methods=doc.verification_method
+            doc.did, methods=doc.verification_method
         )
         builder.authentication = RelationshipBuilder(
-            doc.id, "auth", methods=doc.authentication
+            doc.did, "auth", methods=doc.authentication
         )
         builder.assertion_method = RelationshipBuilder(
-            doc.id, "assert", methods=doc.assertion_method
+            doc.did, "assert", methods=doc.assertion_method
         )
         builder.key_agreement = RelationshipBuilder(
-            doc.id, "key-agreement", methods=doc.key_agreement
+            doc.did, "key-agreement", methods=doc.key_agreement
         )
         builder.capability_invocation = RelationshipBuilder(
-            doc.id, "capability-invocation", methods=doc.capability_invocation
+            doc.did, "capability-invocation", methods=doc.capability_invocation
         )
         builder.capability_delegation = RelationshipBuilder(
-            doc.id, "capability-delegation", methods=doc.capability_delegation
+            doc.did, "capability-delegation", methods=doc.capability_delegation
         )
-        builder.services = ServiceBuilder(doc.id, services=doc.service)
+        builder.services = ServiceBuilder(doc.did, services=doc.service)
         return builder
 
     def build(self) -> DIDDocument:
         """Build document."""
         return DIDDocument(
-            id=self.id,
+            id=str(self.id),
             context=self.context,
             also_known_as=self.also_known_as,
             controller=self.controller,

--- a/pydid/doc/didcomm_service.py
+++ b/pydid/doc/didcomm_service.py
@@ -17,6 +17,7 @@ class DIDCommService(Service):
             "type": Any("IndyAgent", "did-communication"),
             "recipientKeys": [All(str, DIDUrl.validate)],
             "routingKeys": [All(str, DIDUrl.validate)],
+            "priority": int,
         },
         extra=PREVENT_EXTRA,
     )
@@ -26,6 +27,7 @@ class DIDCommService(Service):
         id_: DIDUrl,
         endpoint: str,
         recipient_keys: List[DIDUrl],
+        priority: int,
         *,
         type_: str = None,
         routing_keys: List[DIDUrl] = None
@@ -34,6 +36,7 @@ class DIDCommService(Service):
         super().__init__(id_, type_ or "did-communication", endpoint)
         self._recipient_keys = recipient_keys
         self._routing_keys = routing_keys or []
+        self.priority = priority
 
     @property
     def recipient_keys(self):
@@ -54,6 +57,7 @@ class DIDCommService(Service):
             "serviceEndpoint": self.endpoint,
             "recipientKeys": did_urls(self.recipient_keys),
             "routingKeys": did_urls(self.routing_keys),
+            "priority": self.priority,
         }
 
     @classmethod
@@ -78,6 +82,7 @@ class DIDCommService(Service):
                 Into("serviceEndpoint", "endpoint"): str,
                 Into("recipientKeys", "recipient_keys"): [DIDUrl.parse],
                 Into("routingKeys", "routing_keys"): [DIDUrl.parse],
+                "priority": int,
             }
         )
         value = deserializer(value)

--- a/pydid/doc/didcomm_service.py
+++ b/pydid/doc/didcomm_service.py
@@ -33,10 +33,17 @@ class DIDCommService(Service):
         routing_keys: List[DIDUrl] = None
     ):
         """Initialize DIDCommService."""
-        super().__init__(id_, type_ or "did-communication", endpoint)
         self._recipient_keys = recipient_keys
         self._routing_keys = routing_keys or []
         self.priority = priority
+        super().__init__(
+            id_,
+            type_ or "did-communication",
+            endpoint,
+            recipient_keys=recipient_keys,
+            routing_keys=routing_keys,
+            priority=priority,
+        )
 
     @property
     def recipient_keys(self):

--- a/pydid/doc/doc.py
+++ b/pydid/doc/doc.py
@@ -49,7 +49,7 @@ class DIDDocument:
 
     def __init__(
         self,
-        id: Union[str, DID],
+        id: str,
         context: List[Any],
         *,
         also_known_as: List[str] = None,
@@ -142,12 +142,17 @@ class DIDDocument:
     @properties.add(
         required=True,
         validate=All(str, DID.validate),
-        serialize=Coerce(str),
-        deserialize=Coerce(DID),
+        serialize=str,
+        deserialize=str,
     )
     def id(self):
         """Return id."""
         return self._id
+
+    @property
+    def did(self):
+        """Return the DID representation of id."""
+        return DID(self._id)
 
     @property
     @properties.add(data_key="alsoKnownAs", validate=[str])

--- a/pydid/doc/service.py
+++ b/pydid/doc/service.py
@@ -18,7 +18,7 @@ class Service:
         {
             "id": All(str, DIDUrl.validate),
             "type": str,
-            "serviceEndpoint": Switch(DIDUrl.validate, Url()),
+            "serviceEndpoint": Switch(DIDUrl.validate, Url(), ""),
         },
         extra=ALLOW_EXTRA,
         required=True,

--- a/tests/doc/test_didcomm_service.py
+++ b/tests/doc/test_didcomm_service.py
@@ -15,6 +15,7 @@ SERVICE0 = {
         "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
         "#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
     ],
+    "priority": 0,
 }
 
 SERVICE1 = {
@@ -23,6 +24,7 @@ SERVICE1 = {
     "serviceEndpoint": "https://agents-r-us.com",
     "recipientKeys": ["did:example:123#keys-1"],
     "routingKeys": [],
+    "priority": 0,
 }
 
 SERVICE2 = {
@@ -31,6 +33,7 @@ SERVICE2 = {
     "serviceEndpoint": "https://agents-r-us.com",
     "recipientKeys": ["did:example:123#keys-1"],
     "routingKeys": [],
+    "priority": 0,
 }
 
 SERVICES = [SERVICE0, SERVICE1, SERVICE2]

--- a/tests/doc/test_doc.py
+++ b/tests/doc/test_doc.py
@@ -402,6 +402,7 @@ def test_programmatic_construction_didcomm():
                 "serviceEndpoint": "https://example.com",
                 "recipientKeys": ["did:example:123#keys-0"],
                 "routingKeys": ["did:example:123#keys-1"],
+                "priority": 0,
             }
         ],
     }

--- a/tests/doc/test_doc.py
+++ b/tests/doc/test_doc.py
@@ -18,6 +18,7 @@ from pydid.doc.builder import (
 )
 from pydid.doc.doc_options import DIDDocumentOption
 from pydid.doc.service import Service
+from pydid.doc.didcomm_service import DIDCommService
 from pydid.doc.verification_method import VerificationMethod, VerificationSuite
 
 DOC0 = {
@@ -243,7 +244,39 @@ DOC6 = {
     ],
 }
 
-DOCS = [DOC0, DOC1, DOC2, DOC3, DOC4, DOC5, DOC6]
+DOC7 = {
+    "@context": "https://www.w3.org/ns/did/v1",
+    "id": "did:example:123",
+    "verificationMethod": [
+        {
+            "id": "did:example:123#keys-0",
+            "type": "Ed25519VerificationKey2018",
+            "controller": "did:example:123",
+            "publicKeyBase58": "1234",
+        }
+    ],
+    "authentication": [
+        "did:example:123#keys-0",
+        {
+            "id": "did:example:123#auth-0",
+            "type": "Ed25519VerificationKey2018",
+            "controller": "did:example:123",
+            "publicKeyBase58": "abcd",
+        },
+    ],
+    "service": [
+        {
+            "id": "did:example:123#service-0",
+            "type": "did-communication",
+            "serviceEndpoint": "https://example.com",
+            "recipientKeys": ["did:example:123#keys-0"],
+            "routingKeys": ["did:example:123#keys-1"],
+            "priority": 0,
+        }
+    ],
+}
+
+DOCS = [DOC0, DOC1, DOC2, DOC3, DOC4, DOC5, DOC6, DOC7]
 
 INVALID_DOC0 = {}
 INVALID_DOC1 = {
@@ -343,6 +376,12 @@ def test_extra_preserved():
     doc_raw["additionalAttribute"] = {"extra": "junk"}
     doc = DIDDocument.deserialize(doc_raw)
     assert "additionalAttribute" in doc.serialize()
+
+
+def test_didcomm_service_deserialized():
+    """Test whether a DIDCommService is returned when deserialized."""
+    doc = DIDDocument.deserialize(DOC7)
+    assert isinstance(doc.service[0], DIDCommService)
 
 
 def test_programmatic_construction():

--- a/tests/doc/test_service.py
+++ b/tests/doc/test_service.py
@@ -19,8 +19,13 @@ SERVICE1 = {
         "#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
     ],
 }
+SERVICE2 = {
+    "id": "did:example:123#linked-domain",
+    "type": "LinkedDomains",
+    "serviceEndpoint": "",
+}
 
-SERVICES = [SERVICE0, SERVICE1]
+SERVICES = [SERVICE0, SERVICE1, SERVICE2]
 
 INVALID_SERVICE0 = {"type": "xdi", "serviceEndpoint": "https://example.com"}
 


### PR DESCRIPTION
Fixed:
- Allow empty service endpoint
- Priority attribute on didcomm service
- Deserialize DIDCommService instead of Service when it is a DIDComm service
- Access DIDCommService custom attributes through "extra" dictionary for compatibility with Service
- `DIDDocument.id` returns a string, `DIDDocument.did` returns a DID