### PR TITLE
kick out partial matches on DID parse

### DIFF
--- a/pydid/common.py
+++ b/pydid/common.py
@@ -1,7 +1,7 @@
 """Common components."""
 import re
 
-DID_PATTERN = re.compile("did:([a-z0-9]+):((?:[a-zA-Z0-9._-]*:)*[a-zA-Z0-9._-]+)")
+DID_PATTERN = re.compile("^did:([a-z0-9]+):((?:[a-zA-Z0-9._-]*:)*[a-zA-Z0-9._-]+)$")
 
 
 class DIDError(Exception):


### PR DESCRIPTION
e.g.,

`did:bad:char'@='acters:example:1234abcd#4`

should fail to parse

Signed-off-by: sklump <srklump@hotmail.com>