### PR TITLE
fixes: consistency and built doc dereferencing

### DIFF
--- a/pydid/doc/builder.py
+++ b/pydid/doc/builder.py
@@ -136,7 +136,7 @@ class ServiceBuilder:
 
     def add_didcomm(
         self,
-        endpoint: str,
+        service_endpoint: str,
         recipient_keys: List[VerificationMethod],
         routing_keys: List[VerificationMethod] = None,
         *,
@@ -150,7 +150,7 @@ class ServiceBuilder:
         priority = priority or self._determine_next_priority()
         service = DIDCommService.make(
             id=self._did.ref(ident),
-            service_endpoint=endpoint,
+            service_endpoint=service_endpoint,
             recipient_keys=[vmethod.id for vmethod in recipient_keys],
             routing_keys=[vmethod.id for vmethod in routing_keys],
             type=type_,

--- a/pydid/doc/builder.py
+++ b/pydid/doc/builder.py
@@ -228,7 +228,7 @@ class DIDDocumentBuilder:
     def build(self) -> DIDDocument:
         """Build document."""
         return DIDDocument.construct(
-            id=str(self.id),
+            id=self.id,
             context=self.context,
             also_known_as=self.also_known_as,
             controller=self.controller,

--- a/pydid/doc/doc.py
+++ b/pydid/doc/doc.py
@@ -148,6 +148,13 @@ class BasicDIDDocument(DIDDocumentRoot):
         """Serialize DID Document to JSON."""
         return self.json()
 
+    @classmethod
+    def construct(cls, **data):
+        """Construct and index."""
+        doc = super(Resource, cls).construct(**data)
+        doc._index_resources()
+        return doc
+
 
 PossibleMethodTypes = Union[KnownVerificationMethods, UnknownVerificationMethod]
 PossibleServiceTypes = Union[DIDCommService, UnknownService]

--- a/tests/doc/test_doc.py
+++ b/tests/doc/test_doc.py
@@ -415,10 +415,10 @@ def test_programmatic_construction_didcomm():
         ExampleVerificationMethod, public_key_example="abcd"
     )
     builder.service.add_didcomm(
-        endpoint="https://example.com", recipient_keys=[key], routing_keys=[route]
+        service_endpoint="https://example.com",
+        recipient_keys=[key],
+        routing_keys=[route],
     )
-    print(builder.build())
-    print(builder.build().serialize())
     assert builder.build().serialize() == {
         "@context": ["https://www.w3.org/ns/did/v1"],
         "id": "did:example:123",
@@ -596,6 +596,15 @@ def test_key_rotation_from_doc():
             }
         ],
     }
+
+
+def test_build_and_dereference():
+    builder = DIDDocumentBuilder("did:example:123")
+    builder.verification_method.add(
+        Ed25519VerificationKey2018, public_key_base58="test", ident="1"
+    )
+    doc = builder.build()
+    assert doc.dereference("#1")
 
 
 def test_dereference_and_membership_check():


### PR DESCRIPTION
Fixes:
- use `service_endpoint` instead of `endpoint` in `add_didcomm` for consistency
- dereferencing from built doc not working as expected