### PR TITLE
improve usability of dereference_as

### DIFF
--- a/pydid/doc/doc.py
+++ b/pydid/doc/doc.py
@@ -230,7 +230,7 @@ class NonconformantDocument(BaseDIDDocument):
         for _, value in self:
             _indexer(value)
 
-    def dereference(self, reference: Union[str, DIDUrl]) -> Any:
+    def dereference(self, reference: Union[str, DIDUrl]) -> Resource:
         """Dereference a DID URL to a document resource."""
         if isinstance(reference, str):
             reference = DIDUrl.parse(reference)

--- a/pydid/resource.py
+++ b/pydid/resource.py
@@ -127,11 +127,14 @@ class IndexedResource(Resource, ABC):
         """Dereference a resource to a specific type."""
         resource = self.dereference(reference)
         if not isinstance(resource, typ):
-            raise ValueError(
-                "Dereferenced resource {} is not an instance of {}".format(
-                    resource, typ.__name__
-                )
-            )
+            try:
+                resource = typ(**resource.dict())
+            except ValueError as error:
+                raise ValueError(
+                    "Dereferenced resource {} could not be parsed as {}".format(
+                        resource, typ.__name__
+                    )
+                ) from error
         return cast(typ, resource)
 
     @classmethod

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,11 +1,24 @@
 """Test Resource."""
 
+from pydid.verification_method import VerificationMethod
+from typing import Optional
 import pytest
 from pydid.resource import Resource, IndexedResource
 
 
-def test_resource():
-    Resource()
+@pytest.fixture
+def mock_indexed_resource():
+    def _mock_indexed_resource(return_value=None):
+        class MockIndexedResource(IndexedResource):
+            def _index_resources(self):
+                pass
+
+            def dereference(self, reference: str) -> Resource:
+                return return_value
+
+        return MockIndexedResource()
+
+    yield _mock_indexed_resource
 
 
 def test_resource_json_transforms():
@@ -16,20 +29,48 @@ def test_resource_json_transforms():
     assert Test.from_json('{"one": "test"}') == Test(one="test")
 
 
-def test_dereference_as():
+def test_dereference_as_compatible(mock_indexed_resource):
     class One(Resource):
-        pass
+        common: str
+        optiona: Optional[str] = None
 
     class Two(Resource):
-        pass
+        common: str
 
-    class Test(IndexedResource):
-        def _index_resources(self):
-            pass
+    test = mock_indexed_resource(One(common="common"))
+    assert isinstance(test.dereference_as(One, "test"), One)
+    assert isinstance(test.dereference_as(Two, "test"), Two)
 
-        def dereference(self, reference: str) -> Resource:
-            return One()
 
-    assert isinstance(Test().dereference_as(One, "test"), One)
+def test_dereference_as_incompatible(mock_indexed_resource):
+    class One(Resource):
+        one: str
+
+    class Two(Resource):
+        two: str
+
+    test = mock_indexed_resource(One(one="one"))
+    assert isinstance(test.dereference_as(One, "test"), One)
     with pytest.raises(ValueError):
-        Test().dereference_as(Two, "test")
+        test.dereference_as(Two, "test")
+
+
+def test_dereference_as_vmethod(mock_indexed_resource):
+    resource = Resource(
+        id="did:example:123#key-1",
+        controller="did:example:123",
+        type="Ed25519VerificationKey2018",
+        public_key_base58="testing",
+    )
+    test = mock_indexed_resource(resource)
+    result = test.dereference_as(VerificationMethod, "test")
+    assert isinstance(result, VerificationMethod)
+    assert result.public_key_base58 == "testing"
+    assert result.material == "testing"
+
+
+def test_dereference_as_vmethod_x(mock_indexed_resource):
+    resource = Resource(type="agent", service_endpoint="http://example.com")
+    test = mock_indexed_resource(resource)
+    with pytest.raises(ValueError):
+        test.dereference_as(VerificationMethod, "test")


### PR DESCRIPTION
This method was previously not very useful in the non-conformant doc case. The method will now attempt to cast the resource to the given resource type if possible.