### PR TITLE
feat: perform full parsing on dereference as

### DIFF
--- a/pydid/resource.py
+++ b/pydid/resource.py
@@ -1,7 +1,7 @@
 """Resource class that forms the base of all DID Document components."""
 from abc import ABC, abstractmethod
 import json
-from typing import Any, Dict, Type, TypeVar, cast
+from typing import Any, Dict, Type, TypeVar
 
 from inflection import camelize
 from pydantic import BaseModel, Extra, parse_obj_as
@@ -126,16 +126,14 @@ class IndexedResource(Resource, ABC):
     def dereference_as(self, typ: Type[ResourceType], reference: str) -> ResourceType:
         """Dereference a resource to a specific type."""
         resource = self.dereference(reference)
-        if not isinstance(resource, typ):
-            try:
-                resource = typ(**resource.dict())
-            except ValueError as error:
-                raise ValueError(
-                    "Dereferenced resource {} could not be parsed as {}".format(
-                        resource, typ.__name__
-                    )
-                ) from error
-        return cast(typ, resource)
+        try:
+            return parse_obj_as(typ, resource.dict())
+        except ValueError as error:
+            raise ValueError(
+                "Dereferenced resource {} could not be parsed as {}".format(
+                    resource, typ.__name__
+                )
+            ) from error
 
     @classmethod
     def construct(cls, **data):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,6 +1,10 @@
 """Test Resource."""
 
-from pydid.verification_method import VerificationMethod
+from pydid.verification_method import (
+    Ed25519VerificationKey2018,
+    KnownVerificationMethods,
+    VerificationMethod,
+)
 from typing import Optional
 import pytest
 from pydid.resource import Resource, IndexedResource
@@ -74,3 +78,18 @@ def test_dereference_as_vmethod_x(mock_indexed_resource):
     test = mock_indexed_resource(resource)
     with pytest.raises(ValueError):
         test.dereference_as(VerificationMethod, "test")
+
+
+def test_dereference_as_vmethod_using_known_methods(mock_indexed_resource):
+    resource = Resource(
+        id="did:example:123#key-1",
+        controller="did:example:123",
+        type="Ed25519VerificationKey2018",
+        public_key_base58="testing",
+    )
+    test = mock_indexed_resource(resource)
+    result = test.dereference_as(KnownVerificationMethods, "test")
+    assert isinstance(result, VerificationMethod)
+    assert isinstance(result, Ed25519VerificationKey2018)
+    assert result.public_key_base58 == "testing"
+    assert result.material == "testing"


### PR DESCRIPTION
This will enable callers to take advantage of Union parsing as in the case of `KnownVerificationMethods`

Signed-off-by: Daniel Bluhm <dbluhm@pm.me>